### PR TITLE
fix issue added query parameter named 'action' with updating 'aura/router'

### DIFF
--- a/src/Provide/Router/AuraRouter.php
+++ b/src/Provide/Router/AuraRouter.php
@@ -89,7 +89,7 @@ class AuraRouter implements RouterInterface
     {
         $request = new RouterMatch;
 
-        $params = $route->params;
+        $params = array_diff_key($route->params, ['action' => null]);
         // path
         $path = substr($params['path'], 0, 1) === '/' ? $this->schemeHost . $params['path'] : $params['path'];
         $request->path = $path;

--- a/src/Provide/Router/AuraRouter.php
+++ b/src/Provide/Router/AuraRouter.php
@@ -89,7 +89,8 @@ class AuraRouter implements RouterInterface
     {
         $request = new RouterMatch;
 
-        $params = array_diff_key($route->params, ['action' => null]);
+        $params = $route->params;
+        unset($params['action']);
         // path
         $path = substr($params['path'], 0, 1) === '/' ? $this->schemeHost . $params['path'] : $params['path'];
         $request->path = $path;

--- a/tests/Provide/Router/AuraRouterTest.php
+++ b/tests/Provide/Router/AuraRouterTest.php
@@ -23,10 +23,20 @@ class AuraRouterTest extends \PHPUnit_Framework_TestCase
         $this->auraRouter = new AuraRouter($this->routerAdapter, 'page://self', new HttpMethodParams);
     }
 
-    public function testMatch()
+    public function testMatchProvider() {
+        return [ 
+            'nameless ' => [null], 
+            'with name' => ['/blog'],
+        ];
+    }
+
+    /**
+     * @dataProvider testMatchProvider
+     */
+    public function testMatch($name)
     {
         $this->routerAdapter
-            ->addPost(null, '/blog/{id}')
+            ->addPost($name, '/blog/{id}')
             ->addValues(['path'  => '/blog']);
         $globals = [
             '_POST' => ['title' => 'hello'],


### PR DESCRIPTION
This parameter is added when specifying route name.
In BEAR.Sunday, it is necessary for route name to generate self link on render stage.

Remaining 'action' query parameter lead to expose internal resource mapped.
