### PR TITLE
add extended router class for BEAR.Sunday

### DIFF
--- a/src/Provide/Router/AuraRoute.php
+++ b/src/Provide/Router/AuraRoute.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of the BEAR.AuraRouterModule package
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\Package\Provide\Router;
+
+use Aura\Router\Exception;
+use Aura\Router\Router as AuraRouter;
+
+/**
+ * A extented router for BEAR.Sunday
+ */
+class AuraRoute extends AuraRouter
+{
+    /**
+     * Adds a route
+     *
+     * @param string $name
+     * @param string $path
+     *
+     * @return $this
+     */
+    public function route($name, $path)
+    {
+        return $this->add($name, $path)->addValues(['path' => $name]);
+    }
+}

--- a/src/Provide/Router/AuraRouterProvider.php
+++ b/src/Provide/Router/AuraRouterProvider.php
@@ -35,7 +35,7 @@ class AuraRouterProvider implements ProviderInterface
     public function __construct(AbstractAppMeta $appMeta, $schemeHost)
     {
         $this->schemeHost = $schemeHost;
-        $router = new Router(new RouteCollection(new RouteFactory), new Generator);
+        $router = new AuraRoute(new RouteCollection(new RouteFactory), new Generator);
         $routeFile = $appMeta->appDir . '/var/conf/aura.route.php';
         include $routeFile;
         $this->router = $router;

--- a/tests/Provide/Router/AuraRouterRouteTest.php
+++ b/tests/Provide/Router/AuraRouterRouteTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace BEAR\Package\Provide\Router;
+
+use Aura\Router\Generator;
+use Aura\Router\RouteCollection;
+use Aura\Router\RouteFactory;
+use Aura\Router\RouterFactory;
+
+class AuraRouterRouteTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AuraRoute
+     */
+    private $route;
+
+    public function setUp()
+    {
+        $this->route = new AuraRoute(new RouteCollection(new RouteFactory), new Generator);
+    }
+
+    public function testRoute() {
+        $this->route->route('/user', '/user/{id}');
+        $routes = $this->route->getRoutes();
+        $expect = [
+            'tokens' => [],
+            'server' => [],
+            'method' => [],
+            'values' => ['action' => '/user', 'path' => '/user'],
+            'secure' => null,
+            'wildcard' => null,
+            'routable' => true,
+            'is_match' => null,
+            'generate' => null,
+        ];
+        $this->assertRoute($expect, $routes['/user']);
+    }
+
+    protected function assertRoute($expect, $actual)
+    {
+        foreach ($expect as $key => $val) {
+            $this->assertSame($val, $actual->$key);
+        }
+    }
+}


### PR DESCRIPTION
``` php
$router->add('/weekday', '/weekday/{year}/{month}/{day}')->addValues(['path' => '/weekday']);
```

add `route()` method to omit  `addValues()` method implementation.

``` php
$router->route(‘/weekday', '/weekday/{year}/{month}/{day}');
```
